### PR TITLE
Added links and keywords to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.14"
 authors = ["spacemeowx2 <spacemeowx2@gmail.com>"]
 edition = "2018"
 description = "Tokio smoltcp"
+documentation = "https://docs.rs/tokio-smoltcp/"
+homepage = "https://github.com/spacemeowx2/tokio-smoltcp"
+repository = "https://github.com/spacemeowx2/tokio-smoltcp.git"
+keywords = ["async", "smoltcp", "tokio"]
+categories = ["asynchronous", "network-programming"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]


### PR DESCRIPTION
Project info on `crates.io` and `docs.rs` is not fully usable without back links to repo.
This PR adds the links and some keywords to be "more visible" on crates.io.