### PR TITLE
Helpers to use UDP socket as device

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 futures = "0.3"
 pin-project-lite = "0.2.6"
 tokio = { version = "1.6.1", features = ["time", "rt"] }
-tokio-util = "0.6.7"
+tokio-util = { version="0.6.7", features = ["net", "codec"] }
 parking_lot = "0.11.1"
 
 [dependencies.smoltcp]
@@ -32,6 +32,8 @@ anyhow = "1.0"
 pcap = "0.8.1"
 structopt = "0.3"
 dns-parser = "0.8"
+log = "0.4"
+env_logger = "0.9"
 
 [features]
 default = [ "proto-ipv4", "proto-ipv6", "raw_socket" ]

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -1,0 +1,16 @@
+#[cfg(unix)]
+use tokio::signal::unix::{signal, SignalKind};
+
+const SIGNAL_HANDLER_FAILED: &str = "failed to install signal handler";
+
+#[cfg(not(unix))]
+pub(crate) async fn shutdown_signal() {
+    tokio::signal::ctrl_c().await.expect(SIGNAL_HANDLER_FAILED)
+}
+
+#[cfg(unix)]
+pub(crate) async fn shutdown_signal() {
+    let mut terminate = signal(SignalKind::terminate()).expect(SIGNAL_HANDLER_FAILED);
+    let mut interrupt = signal(SignalKind::interrupt()).expect(SIGNAL_HANDLER_FAILED);
+    tokio::select!(_ = terminate.recv() => (), _ = interrupt.recv() => ())
+}

--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -1,0 +1,110 @@
+// This example contains implementation for two different endpoints connected
+// over virtual network organized with smoltcp.
+//
+// Endpoints (think of them like a computers in LAN) will send ethernet
+// frames to each other over UDP (UDP is like a wire in your virtual network).
+//
+// You can start server with:
+// cargo run --example udp -- --server
+//
+// and client with:
+// RUST_LOG=trace cargo run --example udp
+//
+// Client will send UDP pings to the server with timeout and server will send
+// pongs back to the client. You can stop server and start it back and see
+// that client will not recieve pong while server is not available.
+//
+// Advanced level
+// You can use socat instead of client or server. Example for client on linux:
+// socat TUN,tun-type=tap,iff-up,iff-no-pi UDP4:127.0.0.1:12345,bind=127.0.0.1:12346
+// ifconfig tap<X> up && ip addr add dev tap<X> 172.19.44.34/20 && ping 172.19.44.33
+// socat UDP4:172.19.44.33:8000 -
+
+use log::{debug, error};
+use smoltcp::wire::{EthernetAddress, IpCidr};
+use std::{net::SocketAddr, time::Duration};
+use structopt::StructOpt;
+use tokio_smoltcp::{join::udp_device, Net, NetConfig};
+mod signals;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    #[structopt(short, long)]
+    server: bool,
+}
+
+async fn client_task(net: Net, server_address: SocketAddr) -> anyhow::Result<()> {
+    let udp = net.udp_bind("0.0.0.0:0".parse()?).await?;
+    let mut packet_counter = 0;
+    let mut answer = [0u8; 1024];
+    loop {
+        udp.send_to(b"12345", server_address).await?;
+        debug!("sent packet {} to {:?}", packet_counter, server_address);
+        tokio::select!(
+            Ok((size, addr)) = udp.recv_from(&mut answer) => {
+                debug!("received {:?}, from {:?}", &answer[..size], addr);
+            },
+            _ = tokio::time::sleep(Duration::from_millis(1000)) => {
+                error!("response {} timed out", packet_counter);
+            },
+        );
+        packet_counter += 1;
+    }
+}
+
+async fn server_task(net: Net) -> anyhow::Result<()> {
+    let udp = net.udp_bind("0.0.0.0:8000".parse()?).await?;
+    let mut answer = [0u8; 1024];
+    loop {
+        let (size, addr) = udp.recv_from(&mut answer).await?;
+        debug!("received {:?}, from {:?}", &answer[..size], addr);
+        udp.send_to(b"12345", addr).await?;
+        debug!("sent packet back to {:?}", addr);
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+
+    let opt = Opt::from_args();
+
+    let server_address: String = "172.19.44.33".to_string();
+
+    // network-over-udp addresses
+    let (ethernet_addr, ip_addr) = if opt.server {
+        ("00:01:02:03:04:05", format!("{}/20", server_address))
+    } else {
+        ("00:01:02:03:04:06", "172.19.44.34/20".to_string())
+    };
+    let ethernet_addr: EthernetAddress = ethernet_addr.parse().unwrap();
+    let ip_addr: IpCidr = ip_addr.parse().unwrap();
+
+    // outside network communication addresses
+    let (local_addr, remote_addr) = if opt.server {
+        ("127.0.0.1:12345", "127.0.0.1:12346")
+    } else {
+        ("127.0.0.1:12346", "127.0.0.1:12345")
+    };
+
+    let (net, fut) = Net::new(
+        udp_device(local_addr.parse().unwrap(), remote_addr.parse().unwrap()).await?,
+        NetConfig {
+            ethernet_addr,
+            ip_addr,
+            gateway: Vec::new(),
+            buffer_size: Default::default(),
+        },
+    );
+    tokio::spawn(fut);
+    if opt.server {
+        tokio::spawn(server_task(net));
+    } else {
+        tokio::spawn(client_task(
+            net,
+            format!("{}:8000", server_address).parse().unwrap(),
+        ));
+    };
+
+    Ok(signals::shutdown_signal().await)
+}

--- a/src/join.rs
+++ b/src/join.rs
@@ -1,0 +1,89 @@
+use crate::{device::Packet, FutureDevice};
+use futures::{
+    task::{Context, Poll},
+    Sink, SinkExt, Stream, StreamExt,
+};
+use std::{net::SocketAddr, pin::Pin};
+use tokio::net::UdpSocket;
+use tokio_util::{codec::BytesCodec, udp::UdpFramed};
+
+pub struct JoinInterface<T> {
+    sink: Box<dyn Sink<T, Error = std::io::Error> + Send + Unpin>,
+    stream: Box<dyn Stream<Item = T> + Send + Unpin>,
+}
+
+impl<T> JoinInterface<T> {
+    pub fn new(
+        sink: Box<dyn Sink<T, Error = std::io::Error> + Send + Unpin>,
+        stream: Box<dyn Stream<Item = T> + Send + Unpin>,
+    ) -> Self {
+        JoinInterface {
+            sink: sink,
+            stream: stream,
+        }
+    }
+}
+
+impl<T> Stream for JoinInterface<T> {
+    type Item = T;
+
+    #[inline(always)]
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        ctx: &mut Context<'_>,
+    ) -> Poll<Option<<Self as futures::Stream>::Item>> {
+        Pin::new(&mut self.stream).poll_next(ctx)
+    }
+}
+
+impl<T> Sink<T> for JoinInterface<T> {
+    type Error = std::io::Error;
+
+    #[inline(always)]
+    fn poll_ready(
+        mut self: Pin<&mut Self>,
+        ctx: &mut Context<'_>,
+    ) -> Poll<Result<(), <Self as futures::Sink<T>>::Error>> {
+        Pin::new(&mut self.sink).poll_ready(ctx)
+    }
+
+    #[inline(always)]
+    fn start_send(
+        mut self: Pin<&mut Self>,
+        ctx: T,
+    ) -> Result<(), <Self as futures::Sink<T>>::Error> {
+        Pin::new(&mut self.sink).start_send(ctx)
+    }
+
+    #[inline(always)]
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        ctx: &mut Context<'_>,
+    ) -> Poll<Result<(), <Self as futures::Sink<T>>::Error>> {
+        Pin::new(&mut self.sink).poll_flush(ctx)
+    }
+
+    #[inline(always)]
+    fn poll_close(
+        mut self: Pin<&mut Self>,
+        ctx: &mut Context<'_>,
+    ) -> Poll<Result<(), <Self as futures::Sink<T>>::Error>> {
+        Pin::new(&mut self.sink).poll_close(ctx)
+    }
+}
+
+pub async fn udp_device(
+    local: SocketAddr,
+    remote: SocketAddr,
+) -> Result<FutureDevice<JoinInterface<Packet>>, std::io::Error> {
+    let socket = UdpSocket::bind(local).await?;
+    let (sink, stream) = UdpFramed::new(socket, BytesCodec::new()).split();
+
+    Ok(FutureDevice::new(
+        JoinInterface::new(
+            Box::new(sink.with(move |x: Packet| futures::future::ready(Ok((x.into(), remote))))),
+            Box::new(stream.map(|v| v.unwrap().0.to_vec())),
+        ),
+        1500,
+    ))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub use socket_allocator::BufferSize;
 use tokio::sync::Notify;
 
 pub mod device;
+pub mod join;
 mod reactor;
 mod socket;
 mod socket_allocator;


### PR DESCRIPTION
### Motivation
smoltcp brings many possibilities to implement virtual networks. implemented helpers brings the fast playground for testing different ideas locally without needs for root privileges and any networking besides localhost.

udp example shows how the virtual network with two endpoints (working in different processes) can be implemented.