### PR TITLE
Update to latest versions of things

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tokio-smoltcp"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["spacemeowx2 <spacemeowx2@gmail.com>"]
-edition = "2018"
+edition = "2024"
 description = "An asynchronous wrapper for smoltcp."
 documentation = "https://docs.rs/tokio-smoltcp/"
 homepage = "https://github.com/spacemeowx2/tokio-smoltcp"
@@ -13,13 +13,13 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 futures = "0.3"
-pin-project-lite = "0.2.6"
-tokio = { version = "1.6.1", features = ["time", "rt"] }
-tokio-util = "0.7.4"
-parking_lot = "0.12.0"
+pin-project-lite = "0.2"
+tokio = { version = "1", features = ["macros", "net", "time", "rt"] }
+tokio-util = "0.7"
+parking_lot = "0.12"
 
 [dependencies.smoltcp]
-version = "0.10.0"
+version = "0.12"
 default-features = false
 features = [
     "std",
@@ -32,12 +32,12 @@ features = [
 ]
 
 [dev-dependencies]
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 anyhow = "1.0"
 pcap = "1.0.0"
 structopt = "0.3"
 dns-parser = "0.8"
-rand = "0.8.5"
+rand = "0.9"
 
 [features]
 default = ["proto-ipv4", "proto-ipv6", "raw_socket"]

--- a/src/device.rs
+++ b/src/device.rs
@@ -50,7 +50,7 @@ pub struct BufferRxToken(Packet);
 impl RxToken for BufferRxToken {
     fn consume<R, F>(mut self, f: F) -> R
     where
-        F: FnOnce(&mut [u8]) -> R,
+        F: FnOnce(&[u8]) -> R,
     {
         let p = &mut self.0;
         let result = f(p);

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1,7 +1,7 @@
 use super::{reactor::Reactor, socket_allocator::SocketHandle};
 use futures::future::{self, poll_fn};
 use futures::{ready, Stream};
-pub use smoltcp::socket::{raw, tcp, udp, AnySocket, Socket};
+pub use smoltcp::socket::{raw, tcp, udp};
 use smoltcp::wire::{IpAddress, IpEndpoint, IpProtocol, IpVersion};
 use std::mem::replace;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};


### PR DESCRIPTION
There's a rustsec advisory open against an indirect dependency of smoltcp 0.10:
  https://rustsec.org/advisories/RUSTSEC-2023-0089

Update to the latest version of things to avoid complaints from `cargo deny check`.  Also be less strict about what version of things to use so that there are fewer copies of crates being used.