### PR TITLE
Allow a lazy (future) tcp connection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@ use std::{
     io,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::{
-        atomic::{AtomicU16, Ordering},
         Arc,
+        atomic::{AtomicU16, Ordering},
     },
 };
 
@@ -142,6 +142,17 @@ impl Net {
             addr.into(),
         )
         .await
+    }
+    pub fn tcp_connect_lazy(
+        &self,
+        addr: SocketAddr,
+    ) -> (
+        SocketAddr,
+        impl Future<Output = Result<TcpStream, std::io::Error>>,
+    ) {
+        let local_endpoint: SocketAddr = (self.ip_addr.address(), self.get_port()).into();
+        let future = TcpStream::connect(self.reactor.clone(), local_endpoint.into(), addr.into());
+        (local_endpoint, future)
     }
     /// This function will create a new UDP socket and attempt to bind it to the `addr` provided.
     pub async fn udp_bind(&self, addr: SocketAddr) -> io::Result<UdpSocket> {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1,6 +1,6 @@
 use super::{reactor::Reactor, socket_allocator::SocketHandle};
 use futures::future::{self, poll_fn};
-use futures::{ready, Stream};
+use futures::{Stream, ready};
 pub use smoltcp::socket::{raw, tcp, udp};
 use smoltcp::wire::{IpAddress, IpEndpoint, IpProtocol, IpVersion};
 use std::mem::replace;
@@ -109,9 +109,11 @@ impl TcpStream {
             // avoid lock inversion deadlocks, but drop it before constructing
             // the TcpStream to avoid a second mutable borror of the reactor.
             let mut context = reactor.context();
-            reactor
-                .get_socket::<tcp::Socket>(*handle)
-                .connect(&mut context, remote_endpoint, local_endpoint)
+            reactor.get_socket::<tcp::Socket>(*handle).connect(
+                &mut context,
+                remote_endpoint,
+                local_endpoint,
+            )
         };
         connect_result.map_err(map_err)?;
 


### PR DESCRIPTION
I had a use case for obtaining the local endpoint of a TcpStream before the connection was resolved. 
If you like it it would nice to have it merged so i don't need to rely on a patch :-)
